### PR TITLE
Fix BattleWrench link on wrenches page

### DIFF
--- a/docs/wrenches/index.md
+++ b/docs/wrenches/index.md
@@ -24,7 +24,7 @@ a similar item, some of which are compatible with the CoFH mods.
 
 ### Redstone Arsenal
 * [Flux-Infused OmniWrench](/docs/flux-infused-omniwrench/)
-* [Flux-Infused BattleWrench](/docs/flux-infused-omniwrench/)
+* [Flux-Infused BattleWrench](/docs/flux-infused-battlewrench/)
 
 
 Usage


### PR DESCRIPTION
Flux-Infused BattleWrench link on `/docs/wrenches/` should lead to `/docs/flux-infused-battlewrench/` instead of `/docs/flux-infused-omniwrench/`