### PR TITLE
Script and style registration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 Thumbs.db
 .jekyll-metadata
 Gemfile.lock
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ exclude:
   - /*.xcf
   - /Thumbs.db
   - /.unused
+  - /vendor
 
 plugins:
   - jekyll-paginate

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,12 +35,20 @@
         <link rel="stylesheet" href="/assets/css/uikit/components/tooltip.min.css" />
         <link rel="stylesheet" href="/assets/css/cofh.css{{cache_buster}}" />
 
+        {% for style in page.styles %}
+        <link rel="stylesheet" href="{{ css }}" />
+        {% endfor %}
+
         <script src="/assets/js/jquery.min.js"></script>
         <script src="/assets/js/uikit/uikit.min.js"></script>
         <script src="/assets/js/uikit/components/autocomplete.min.js"></script>
         <script src="/assets/js/uikit/components/sticky.min.js"></script>
         <script src="/assets/js/uikit/components/tooltip.min.js"></script>
         <script src="/assets/js/cofh.js{{cache_buster}}"></script>
+        
+        {% for script in page.scripts %}
+        <script src="{{ script }}"></script>
+        {% endfor %}
     </head>
 
     <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
         <link rel="stylesheet" href="/assets/css/cofh.css{{cache_buster}}" />
 
         {% for style in page.styles %}
-        <link rel="stylesheet" href="{{ css }}" />
+        <link rel="stylesheet" href="{{ style }}" />
         {% endfor %}
 
         <script src="/assets/js/jquery.min.js"></script>
@@ -45,7 +45,7 @@
         <script src="/assets/js/uikit/components/sticky.min.js"></script>
         <script src="/assets/js/uikit/components/tooltip.min.js"></script>
         <script src="/assets/js/cofh.js{{cache_buster}}"></script>
-        
+
         {% for script in page.scripts %}
         <script src="{{ script }}"></script>
         {% endfor %}


### PR DESCRIPTION
See discussion in #84 for rationale.

This allows us to register styles and scripts per page/layout by simply specifying them in the YAML front matter.

This means we can only include expensive UIKit files as and where needed. Currently this isn't being used anywhere but I plan to make use of it in my big upcoming docs PR.

# Example

```yaml
---
scripts:
  - /assets/css/uikit/components/autocomplete.min.js
styles:
  - /assets/css/uikit/components/autocomplete.min.css
---
```

There are two arguably unrelated commits in here but I don't feel that it's an issue personally.

# Excluding vendor.

I was basically unable to run the site locally until I fixed [this issue](https://github.com/jekyll/jekyll/issues/2938#issuecomment-56237068).

# Ignoring vendor.

Shouldn't it be ignored anyway? Without it there's several thousand files in my sidebar and any PR I made would mean that the entire vendor directory would be included... I honestly don't understand why it's not ignored as is.